### PR TITLE
Install Android Build Tools 29.0.3 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
     - name: Setup Android SDK
       uses: android-actions/setup-android@v3
 
+    - name: Install Android Build Tools 29.0.3
+      run: sdkmanager "build-tools;29.0.3"
+
     - name: Cache Gradle packages
       uses: actions/cache@v4
       with:


### PR DESCRIPTION
Added step to install Android Build Tools version 29.0.3.